### PR TITLE
Add FastAPI-based todo backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Cross-Platform Productivity Suite
+
+This repository hosts a set of applications starting with a basic To-Do list backend. The backend is built with [FastAPI](https://fastapi.tiangolo.com/) and provides simple CRUD endpoints for tasks.
+
+## Running the Backend
+
+Install dependencies and run the tests:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r backend/requirements.txt
+pytest
+```
+
+Start the development server:
+
+```bash
+uvicorn backend.app.main:app --reload
+```
+
+The API will be available at `http://localhost:8000`.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,63 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import Dict, List, Optional
+from datetime import datetime
+
+app = FastAPI()
+
+class TaskBase(BaseModel):
+    title: str
+    description: Optional[str] = None
+    status: str = "pending"
+    due_date: Optional[datetime] = None
+
+class TaskCreate(TaskBase):
+    pass
+
+class TaskUpdate(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    status: Optional[str] = None
+    due_date: Optional[datetime] = None
+
+class Task(TaskBase):
+    id: int
+
+_tasks: Dict[int, Task] = {}
+_next_id = 1
+
+@app.post("/tasks", response_model=Task)
+def create_task(task: TaskCreate):
+    global _next_id
+    task_obj = Task(id=_next_id, **task.dict())
+    _tasks[_next_id] = task_obj
+    _next_id += 1
+    return task_obj
+
+@app.get("/tasks", response_model=List[Task])
+def list_tasks():
+    return list(_tasks.values())
+
+@app.get("/tasks/{task_id}", response_model=Task)
+def get_task(task_id: int):
+    task = _tasks.get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return task
+
+@app.put("/tasks/{task_id}", response_model=Task)
+def update_task(task_id: int, task_update: TaskUpdate):
+    existing = _tasks.get(task_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Task not found")
+    update_data = task_update.dict(exclude_unset=True)
+    updated = existing.copy(update=update_data)
+    _tasks[task_id] = updated
+    return updated
+
+@app.delete("/tasks/{task_id}")
+def delete_task(task_id: int):
+    if task_id not in _tasks:
+        raise HTTPException(status_code=404, detail="Task not found")
+    del _tasks[task_id]
+    return {"ok": True}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pytest

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+def test_create_and_read_task():
+    response = client.post("/tasks", json={"title": "Test Task"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "Test Task"
+    task_id = data["id"]
+
+    response = client.get("/tasks")
+    assert response.status_code == 200
+    tasks = response.json()
+    assert any(t["id"] == task_id for t in tasks)
+
+    response = client.get(f"/tasks/{task_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == task_id
+
+def test_update_and_delete_task():
+    response = client.post("/tasks", json={"title": "Old Title"})
+    task_id = response.json()["id"]
+
+    response = client.put(f"/tasks/{task_id}", json={"title": "New Title"})
+    assert response.status_code == 200
+    assert response.json()["title"] == "New Title"
+
+    response = client.delete(f"/tasks/{task_id}")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+    response = client.get(f"/tasks/{task_id}")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add FastAPI app with CRUD endpoints for tasks
- include pytest tests for task creation, retrieval, update, and deletion
- document setup instructions in README

## Testing
- `python -m py_compile backend/app/main.py backend/tests/test_tasks.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688c6a6e3e40832c9fd30d04f3876f72